### PR TITLE
fix(package.json): correct repository and bugs URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,9 +249,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/electroloom/electroloom.git"
+    "url": "https://github.com/jmassardo/electrosim.git"
   },
   "bugs": {
-    "url": "https://github.com/electroloom/electroloom/issues"
+    "url": "https://github.com/jmassardo/electrosim/issues"
   }
 }


### PR DESCRIPTION
Closes #110. Updates `repository.url` and `bugs.url` from the legacy `electroloom/electroloom` to `jmassardo/electrosim` so npm tooling (`npm bugs`, `npm repo`, registry page) points to the right repo.